### PR TITLE
hide no data if no data message is null or empty

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -190,7 +190,8 @@ class SuperTreeview extends Component {
             depth,
             transitionEnterTimeout,
             transitionExitTimeout,
-            getStyleClassCb
+            getStyleClassCb,
+            noChildrenAvailableMessage
         } = this.props;
         const {
             printExpandButton,
@@ -212,7 +213,7 @@ class SuperTreeview extends Component {
 
         return (
             <TransitionGroup>
-                {isEmpty(nodeArray)
+                {isEmpty(nodeArray) && noChildrenAvailableMessage
                     ? this.printNoChildrenMessage()
                     : nodeArray.map((node, index) => {
                           const nodeText = get(node, keywordLabel, '');
@@ -338,8 +339,8 @@ SuperTreeview.defaultProps = {
     isDeletable: (/* node, depth */) => {
         return true;
     },
-    isExpandable: (/* node, depth */) => {
-        return true;
+    isExpandable: (node, depth) => {
+        return node.children && node.children.length > 0;
     },
 
     keywordChildren: 'children',

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -653,7 +653,7 @@ describe('<SuperTreeview />', () => {
             expandToggleBtn = component
                 .find('.super-treeview')
                 .find('TransitionGroup')
-                .childAt(0)
+                .childAt(1)
                 .find(expandToggleBtnSelector);
         });
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -629,7 +629,8 @@ describe('<SuperTreeview />', () => {
     describe('handleExpandToggle()', () => {
         let component,
             onExpandToggleCbStub,
-            expandToggleBtn,
+            firstExpandToggleBtn,
+            secondExpandToggleBtn,
             handleExpandToggleSpy;
 
         beforeEach(() => {
@@ -650,7 +651,12 @@ describe('<SuperTreeview />', () => {
             component = shallow(<SuperTreeview {...props} />)
 
             const expandToggleBtnSelector = '.super-treeview-triangle-btn';
-            expandToggleBtn = component
+            firstExpandToggleBtn = component
+                .find('.super-treeview')
+                .find('TransitionGroup')
+                .childAt(0)
+                .find(expandToggleBtnSelector);
+            secondExpandToggleBtn = component
                 .find('.super-treeview')
                 .find('TransitionGroup')
                 .childAt(1)
@@ -658,8 +664,15 @@ describe('<SuperTreeview />', () => {
         });
 
         it('should toggle tree on expand', () => {
-            expandToggleBtn.simulate('click');
+            secondExpandToggleBtn.simulate('click');
 
+            expect(handleExpandToggleSpy).have.been.calledOnce;
+            expect(onExpandToggleCbStub).have.been.calledOnce;
+
+            firstExpandToggleBtn.simulate('click');
+
+            // still only fired once because there is no expand button for the first data element
+            // because it has no children
             expect(handleExpandToggleSpy).have.been.calledOnce;
             expect(onExpandToggleCbStub).have.been.calledOnce;
         });


### PR DESCRIPTION
adding default function body for isExpandable that checks children length to be higher than zero. It cannot be expected of users to fix this by sending in their own function.