### PR TITLE
Remove old engines entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,6 @@
   "version": "0.3.3-beta.0",
   "description": "React Super Treeview",
   "main": "dist/main.js",
-  "engines": {
-    "node": ">=6.7.0",
-    "npm": ">=4.0.0"
-  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
fixes #25

```
error react-super-treeview@0.3.3: The engine "node" is incompatible with this module. Expected version "^6.7.0". Got "15.12.0"
```